### PR TITLE
Make integrations test pipeline more resilient

### DIFF
--- a/.github/workflows/Deployment.yaml
+++ b/.github/workflows/Deployment.yaml
@@ -22,10 +22,13 @@ jobs:
     env:
       KUBECONFIG: "${{ github.workspace }}/.kubeconfig"
       KUBECONFIG_CONTENT: ${{ secrets.KUBECONFIG_CONTENT }}
+      ENVIRONMENT: ${{ inputs.environment }}
+      WORKSTATION_ID: ${{ vars.WORKSTATION_ID }}
     steps:
       - uses: actions/checkout@v4
 
       - name: "Create kube config"
-        run: echo "$KUBECONFIG_CONTENT" | base64 -d > "$KUBECONFIG"
+        run: "./ci/init_kubectl.sh"
 
-      - run: sh ci/deploy.sh apply
+      - name: "Applying the deployment"
+        run: sh ci/deploy.sh apply

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -27,6 +27,7 @@ env:
   KUBECONFIG: "${{ github.workspace }}/.kubeconfig"
   KUBECONFIG_CONTENT: ${{ secrets.KUBECONFIG_CONTENT }}
   WORKSTATION_ID: ${{ vars.WORKSTATION_ID }}
+  ENVIRONMENT: ${{ inputs.environment }}
 
 jobs:
   deploy:
@@ -45,22 +46,17 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: "Create kube config"
-        run: echo "$KUBECONFIG_CONTENT" | base64 -d > "$KUBECONFIG"
+        run: "./ci/init_kubectl.sh"
 
-      - name: debug
-        run: |
-          stat --printf="Kubeconfig size %s\n" "$KUBECONFIG"
-          printf "KUBECONFIG_CONTENT length: "
-          printf "%b" "$KUBECONFIG_CONTENT" | wc -c
-          echo "ENV: ${{ inputs.environment }}"
-          echo "WORKSTATION_ID $WORKSTATION_ID"
+      - name: "Wait for deployment"
+        run: "sleep 60"
 
       - name: "Trying to curl endpoint"
         run: "./ci/integration_test/curl_endpoint.sh"
 
   teardown:
     name: Teardown test deployment
-    if: ${{ inputs.do_teardown }}
+    if: ${{ inputs.do_teardown && always() }}
     runs-on: ubuntu-22.04
     environment: ${{ inputs.environment }}
     needs:
@@ -69,6 +65,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: "Create kube config"
-        run: echo "$KUBECONFIG_CONTENT" | base64 -d > "$KUBECONFIG"
+        run: "./ci/init_kubectl.sh"
 
-      - run: sh ci/deploy.sh delete
+      - name: "Teardown deployment"
+        run: sh ci/deploy.sh delete

--- a/ci/init_kubectl.sh
+++ b/ci/init_kubectl.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -eu
+print() { printf "%b%b" "${1-""}" "${2-"\\n"}"; }
+stderr() { print "$@" 1>&2; }
+reportError() { stderr "$2"; return "$1"; }
+
+commandv() { command -v "$1" || reportError "$?" "Executable '$1' not found"; }
+
+if [ -z "${KUBECONFIG_CONTENT+x}" ]; then
+	reportError 1 "Missing KUBECONFIG_CONTENT env variable"
+fi
+
+if [ -z "${KUBECONFIG_CONTENT}" ]; then
+	reportError 1 "KUBECONFIG_CONTENT is empty!"
+fi
+
+if [ -z "${KUBECONFIG+x}" ]; then
+	reportError 1 "Missing KUBECONFIG env variable"
+fi
+
+
+print "$KUBECONFIG_CONTENT" | base64 -d > "$KUBECONFIG"
+
+
+print "::group::Environment" # https://github.com/actions/toolkit/blob/main/docs/commands.md#group-and-ungroup-log-lines
+
+print "WORKSTATION_ID: ${WORKSTATION_ID:-"UNKOWN"}"
+print "ENVIRONMENT: ${ENVIRONMENT:-"UNKOWN"}"
+
+stat --printf="Kubeconfig size: %s\n" "$KUBECONFIG"
+
+print "KUBECONFIG_CONTENT length: ${#KUBECONFIG_CONTENT}"
+print "Current context: $(kubectl config current-context)"
+
+print "::endgroup::"

--- a/ci/integration_test/curl_endpoint.sh
+++ b/ci/integration_test/curl_endpoint.sh
@@ -27,19 +27,19 @@ PATHNAME="${PATHNAME:-"healthz"}"
 PROTOCOL="${PROTOCOL:-"http://"}"
 
 
-NODE_PORT="$(kubectl get -o jsonpath='{.spec.ports[0].nodePort}' service "$SERVICE_NAME")"
 
 
 
 get_address() {
+	NODE_PORT="$(kubectl get -o jsonpath='{.spec.ports[0].nodePort}' service "$SERVICE_NAME")"
 	ADDRESS="$(kubectl get -o jsonpath='{range .items[*]}{.status.addresses[?(@.type == "ExternalDNS")].address}{"\n"}{end}' nodes | shuf -n 1 -)"
 	print "${PROTOCOL}${ADDRESS}:$NODE_PORT/$PATHNAME"
 }
 
 fetch() {
-	curl -f "$(get_address)"
+	curl --fail-early -LsS --connect-timeout 60 "$(get_address)"
 }
 
 
-until_timeout 15 fetch
+until_timeout 30 fetch
 stderr "\nSuccess"


### PR DESCRIPTION
This is done by:
- Making curl fail faster.
- Curl may follow redirects.
- Curl is more silent, making logs easier to read.
- Nodeport is fetched again for each retry.
- A sleep delay is enforced before curl testing.
- Teardown is run even if curl test fails, when `do_teardown = true`.

Furthermore has debugging been improved by making dedicated `init_kubectl` script.
This means:
- A consolidated approach to init kubectl config.
- More debugging information for which environment is configured.
- More error handling, and checking for valid configurations.